### PR TITLE
Add preloaded-expect-ct.badssl.com

### DIFF
--- a/domains/cert/preloaded-expect-ct.conf
+++ b/domains/cert/preloaded-expect-ct.conf
@@ -1,0 +1,19 @@
+---
+---
+server {
+  listen 80;
+  server_name preloaded-expect-ct.{{ site.domain }};
+  
+  return 301 https://$server_name$request_uri;
+}
+
+server {
+  listen 443;
+  server_name preloaded-expect-ct.{{ site.domain }};
+
+  include {{ site.serving-path }}/nginx-includes/wildcard.preloaded-expect-ct.conf;
+  include {{ site.serving-path }}/nginx-includes/tls-defaults.conf;
+  include {{ site.serving-path }}/common/common.conf;
+
+  root {{ site.serving-path }}/domains/cert/preloaded-expect-ct;
+}

--- a/domains/cert/preloaded-expect-ct/index.html
+++ b/domains/cert/preloaded-expect-ct/index.html
@@ -1,0 +1,16 @@
+---
+subdomain: preloaded-expect-ct
+layout: page
+favicon: yellow
+background: rgb(246, 207, 47)
+---
+
+<div id="content">
+  <h1>
+    {{ page.subdomain }}.<br>{{ site.domain }}
+  </h1>
+</div>
+
+<div id="footer">
+  This site is on the Expect CT preload list but does not serve SCTs.
+</div>

--- a/nginx-includes/wildcard.preloaded-expect-ct.conf
+++ b/nginx-includes/wildcard.preloaded-expect-ct.conf
@@ -1,0 +1,8 @@
+---
+---
+
+ssl on;
+ssl_certificate {{ site.cert-path }}/wildcard-main.pem;
+ssl_certificate_key /etc/keys/leaf-main.key;
+
+add_header Expect-CT preload;


### PR DESCRIPTION
This subdomain serves the Expect-CT header and is on the Chrome preload
list for Expect-CT, but does not serve SCTs. Visiting it in Chrome
should thus generate and send an Expect-CT report.