### PR TITLE
Added ECC 256 and 384 to BadSSL (Local Only)

### DIFF
--- a/certs/Makefile
+++ b/certs/Makefile
@@ -3,6 +3,7 @@
 # gen-ca    :: crt <= conf, key
 # gen-csr   :: csr <= conf, key
 # gen-key    :: key <= int (#bits)
+# gen-ecckey :: key <= string (ECC Prime)
 # self-sign :: crt <= days, hash, extensions, conf, csr, key (self)
 # sign      :: crt <= days, hash, extensions, conf, csr, key (CA), crt (CA)
 
@@ -186,6 +187,28 @@ $(O)/gen/crt/wildcard-rsa8192.crt: src/conf/wildcard-main.conf $(O)/gen/csr/wild
 	./tool sign $@ $(D) $(SIGN_LEAF_DEFAULTS) $^
 CHAINS_PROD += $(O)/gen/chain/wildcard-rsa8192.pem
 $(O)/gen/chain/wildcard-rsa8192.pem: $(O)/gen/crt/wildcard-rsa8192.crt $(O)/gen/crt/ca-intermediate.crt
+	./tool chain $@ $(D) $^
+
+################################
+$(O)/gen/key/subdomain-ecc256.key:
+	./tool gen-ecckey $@ $(D) prime256v1
+$(O)/gen/csr/subdomain-ecc256.csr: src/conf/subdomain-ecc256.conf $(O)/gen/key/subdomain-ecc256.key
+	./tool gen-csr $@ $(D) $^
+$(O)/gen/crt/subdomain-ecc256.crt: src/conf/subdomain-ecc256.conf $(O)/gen/csr/subdomain-ecc256.csr $(O)/gen/key/ca-intermediate.key $(O)/gen/crt/ca-intermediate.crt
+	./tool sign $@ $(D) $(SIGN_LEAF_DEFAULTS) $^
+CHAINS_LOCAL_ONLY += $(O)/gen/chain/subdomain-ecc256.pem
+$(O)/gen/chain/subdomain-ecc256.pem: $(O)/gen/crt/subdomain-ecc256.crt $(O)/gen/crt/ca-intermediate.crt
+	./tool chain $@ $(D) $^
+
+################################
+$(O)/gen/key/subdomain-ecc384.key:
+	./tool gen-ecckey $@ $(D) secp384r1
+$(O)/gen/csr/subdomain-ecc384.csr: src/conf/subdomain-ecc384.conf $(O)/gen/key/subdomain-ecc384.key
+	./tool gen-csr $@ $(D) $^
+$(O)/gen/crt/subdomain-ecc384.crt: src/conf/subdomain-ecc384.conf $(O)/gen/csr/subdomain-ecc384.csr $(O)/gen/key/ca-intermediate.key $(O)/gen/crt/ca-intermediate.crt
+	./tool sign $@ $(D) $(SIGN_LEAF_DEFAULTS) $^
+CHAINS_LOCAL_ONLY += $(O)/gen/chain/subdomain-ecc384.pem
+$(O)/gen/chain/subdomain-ecc384.pem: $(O)/gen/crt/subdomain-ecc384.crt $(O)/gen/crt/ca-intermediate.crt
 	./tool chain $@ $(D) $^
 
 ################################

--- a/certs/src/conf/subdomain-ecc256.conf
+++ b/certs/src/conf/subdomain-ecc256.conf
@@ -1,0 +1,20 @@
+[ req ]
+default_bits        = 2048
+distinguished_name  = req_distinguished_name
+encrypt_key         = no
+prompt              = no
+req_extensions      = req_v3_usr
+
+[ req_distinguished_name ]
+countryName         = US
+stateOrProvinceName = California
+localityName        = San Francisco
+organizationName    = BadSSL
+commonName          = ecc256.__DOMAIN__
+
+[ req_v3_usr ]
+basicConstraints = CA:FALSE
+subjectAltName = @alt_names
+
+[ alt_names ]
+DNS.1 = ecc256.__DOMAIN__

--- a/certs/src/conf/subdomain-ecc384.conf
+++ b/certs/src/conf/subdomain-ecc384.conf
@@ -1,0 +1,20 @@
+[ req ]
+default_bits        = 2048
+distinguished_name  = req_distinguished_name
+encrypt_key         = no
+prompt              = no
+req_extensions      = req_v3_usr
+
+[ req_distinguished_name ]
+countryName         = US
+stateOrProvinceName = California
+localityName        = San Francisco
+organizationName    = BadSSL
+commonName          = ecc384.__DOMAIN__
+
+[ req_v3_usr ]
+basicConstraints = CA:FALSE
+subjectAltName = @alt_names
+
+[ alt_names ]
+DNS.1 = ecc384.__DOMAIN__

--- a/certs/tool
+++ b/certs/tool
@@ -42,6 +42,12 @@ gen-key)
     -out $OUT \
     $1
   ;;
+gen-ecckey)
+  openssl ecparam \
+    -out $OUT \
+    -name $1 \
+    -genkey
+  ;;
 self-sign)
   openssl x509  -req  -CAcreateserial \
     -out $OUT \

--- a/domains-local-only/cert/ecc256.conf
+++ b/domains-local-only/cert/ecc256.conf
@@ -12,7 +12,7 @@ server {
   server_name ecc256.{{ site.domain }};
 
   include {{ site.serving-path }}/nginx-includes/subdomain-ecc256.conf;
-  include {{ site.serving-path }}/nginx-includes/tls-mozilla-intermediate.conf;
+  include {{ site.serving-path }}/nginx-includes/tls-defaults.conf;
   include {{ site.serving-path }}/common/common.conf;
 
   root {{ site.serving-path }}/domains-local-only/cert/ecc256;

--- a/domains-local-only/cert/ecc256.conf
+++ b/domains-local-only/cert/ecc256.conf
@@ -1,0 +1,19 @@
+---
+---
+server {
+  listen 80;
+  server_name ecc256.{{ site.domain }};
+
+  return 301 https://$server_name$request_uri;
+}
+
+server {
+  listen 443;
+  server_name ecc256.{{ site.domain }};
+
+  include {{ site.serving-path }}/nginx-includes/subdomain-ecc256.conf;
+  include {{ site.serving-path }}/nginx-includes/tls-mozilla-intermediate.conf;
+  include {{ site.serving-path }}/common/common.conf;
+
+  root {{ site.serving-path }}/domains-local-only/cert/ecc256;
+}

--- a/domains-local-only/cert/ecc256/index.html
+++ b/domains-local-only/cert/ecc256/index.html
@@ -1,0 +1,16 @@
+---
+subdomain: ecc256
+layout: page
+favicon: green
+background: green
+---
+
+<div id="content">
+  <h1 style="font-size: 12vw;">
+    {{ page.subdomain }}.<br>{{ site.domain }}
+  </h1>
+</div>
+
+<div id="footer">
+  This site uses a 256 bit ECC (elliptic curve cryptography) certificate.</a>.
+</div>

--- a/domains-local-only/cert/ecc256/index.html
+++ b/domains-local-only/cert/ecc256/index.html
@@ -12,5 +12,5 @@ background: green
 </div>
 
 <div id="footer">
-  This site uses a 256 bit ECC (elliptic curve cryptography) certificate.</a>.
+  This site uses a 256-bit ECC digital certificate.
 </div>

--- a/domains-local-only/cert/ecc384.conf
+++ b/domains-local-only/cert/ecc384.conf
@@ -1,0 +1,19 @@
+---
+---
+server {
+  listen 80;
+  server_name ecc384.{{ site.domain }};
+
+  return 301 https://$server_name$request_uri;
+}
+
+server {
+  listen 443;
+  server_name ecc384.{{ site.domain }};
+
+  include {{ site.serving-path }}/nginx-includes/subdomain-ecc384.conf;
+  include {{ site.serving-path }}/nginx-includes/tls-mozilla-intermediate.conf;
+  include {{ site.serving-path }}/common/common.conf;
+
+  root {{ site.serving-path }}/domains-local-only/cert/ecc384;
+}

--- a/domains-local-only/cert/ecc384.conf
+++ b/domains-local-only/cert/ecc384.conf
@@ -12,7 +12,7 @@ server {
   server_name ecc384.{{ site.domain }};
 
   include {{ site.serving-path }}/nginx-includes/subdomain-ecc384.conf;
-  include {{ site.serving-path }}/nginx-includes/tls-mozilla-intermediate.conf;
+  include {{ site.serving-path }}/nginx-includes/tls-defaults.conf;
   include {{ site.serving-path }}/common/common.conf;
 
   root {{ site.serving-path }}/domains-local-only/cert/ecc384;

--- a/domains-local-only/cert/ecc384/index.html
+++ b/domains-local-only/cert/ecc384/index.html
@@ -12,5 +12,5 @@ background: green
 </div>
 
 <div id="footer">
-  This site uses a 384 bit ECC (elliptic curve cryptography) certificate.</a>.
+  This site uses a 384-bit ECC digital certificate.
 </div>

--- a/domains-local-only/cert/ecc384/index.html
+++ b/domains-local-only/cert/ecc384/index.html
@@ -1,0 +1,16 @@
+---
+subdomain: ecc384
+layout: page
+favicon: green
+background: green
+---
+
+<div id="content">
+  <h1 style="font-size: 12vw;">
+    {{ page.subdomain }}.<br>{{ site.domain }}
+  </h1>
+</div>
+
+<div id="footer">
+  This site uses a 384 bit ECC (elliptic curve cryptography) certificate.</a>.
+</div>

--- a/nginx-includes/subdomain-ecc256.conf
+++ b/nginx-includes/subdomain-ecc256.conf
@@ -1,0 +1,6 @@
+---
+---
+
+ssl on;
+ssl_certificate {{ site.cert-path }}/subdomain-ecc256.pem;
+ssl_certificate_key /etc/keys/subdomain-ecc256.key;

--- a/nginx-includes/subdomain-ecc384.conf
+++ b/nginx-includes/subdomain-ecc384.conf
@@ -1,0 +1,6 @@
+---
+---
+
+ssl on;
+ssl_certificate {{ site.cert-path }}/subdomain-ecc384.pem;
+ssl_certificate_key /etc/keys/subdomain-ecc384.key;


### PR DESCRIPTION
The code has been tested in a Google Compute Engine VM running Debian GNU/Linux 8 (jessie). 
The installation was simple and it was running in minutes using the instructions provided on the main page.

![image](https://cloud.githubusercontent.com/assets/24654097/21506913/e1f7f844-cc6b-11e6-8ceb-925768de16f3.png)

Note: I edited the Makefile locally on the VM to include the domain name for testing purposes. 