### PR TITLE
Http-everywhere should have link to insecure site

### DIFF
--- a/domains/misc/badssl.com/index.html
+++ b/domains/misc/badssl.com/index.html
@@ -115,7 +115,7 @@
     <a href="https://preloaded-hsts.{{ site.domain }}/" class="good"><span class="icon"></span>preloaded-hsts</a>
     <a href="https://subdomain.preloaded-hsts.{{ site.domain }}/" class="bad"><span class="icon"></span>subdomain.preloaded-hsts</a>
     <hr>
-    <a href="https://https-everywhere.{{ site.domain }}/" class="good"><span class="icon"></span>https-everywhere</a>
+    <a href="http://https-everywhere.{{ site.domain }}/" class="good"><span class="icon"></span>https-everywhere</a>
   </div>
   <div class="group">
     <h2 id="miscellaneous"><span class="emoji">💬</span>Miscellaneous</h2>


### PR DESCRIPTION
The http-everywhere domain seeks to test whether the client will upgrade from http to https. The link should therefore point at http. 