### PR TITLE
add protocols to main page

### DIFF
--- a/domains/misc/badssl.com/dashboard/sets.js
+++ b/domains/misc/badssl.com/dashboard/sets.js
@@ -19,8 +19,6 @@ var sets = [
       {subdomain: "superfish"},
       {subdomain: "edellroot"},
       {subdomain: "dsdtestprovider"},
-      {subdomain: "ssl-v2", port: 1002},
-      {subdomain: "ssl-v3", port: 1003},
       {subdomain: "null"}
     ]
   },

--- a/domains/misc/badssl.com/dashboard/sets.js
+++ b/domains/misc/badssl.com/dashboard/sets.js
@@ -19,6 +19,8 @@ var sets = [
       {subdomain: "superfish"},
       {subdomain: "edellroot"},
       {subdomain: "dsdtestprovider"},
+      {subdomain: "ssl-v2", port: 1002},
+      {subdomain: "ssl-v3", port: 1003},
       {subdomain: "null"}
     ]
   },

--- a/domains/misc/badssl.com/index.html
+++ b/domains/misc/badssl.com/index.html
@@ -81,6 +81,13 @@
     <a href="http://http-credit-card.{{ site.domain }}/" class="bad"><span class="icon"></span>http-credit-card</a>
   </div>
   <div class="group">
+    <h2 id="protocol"><span class="emoji">↔️</span>Protocol</h2>
+    <a href="https://ssl-v2.{{ site.domain }}/" class="bad"><span class="icon"></span>SSLv2</a>
+    <a href="https://ssl-v3.{{ site.domain }}/" class="bad"><span class="icon"></span>SSLv3</a>
+    <a href="https://tls-v1-0.{{ site.domain }}/" class="dubious"><span class="icon"></span>TLS 1.0</a>
+    <a href="https://tls-v1-1.{{ site.domain }}/" class="dubious"><span class="icon"></span>TLS 1.1</a>
+  </div>
+  <div class="group">
     <h2 id="cipher-suite"><span class="emoji">🔀</span>Cipher Suite</h2>
     <a href="https://cbc.{{ site.domain }}/" class="dubious"><span class="icon"></span>cbc</a>
     <a href="https://rc4-md5.{{ site.domain }}/" class="bad"><span class="icon"></span>rc4-md5</a>

--- a/domains/misc/badssl.com/index.html
+++ b/domains/misc/badssl.com/index.html
@@ -81,13 +81,6 @@
     <a href="http://http-credit-card.{{ site.domain }}/" class="bad"><span class="icon"></span>http-credit-card</a>
   </div>
   <div class="group">
-    <h2 id="protocol"><span class="emoji">↔️</span>Protocol</h2>
-    <a href="https://ssl-v2.{{ site.domain }}/" class="bad"><span class="icon"></span>SSLv2</a>
-    <a href="https://ssl-v3.{{ site.domain }}/" class="bad"><span class="icon"></span>SSLv3</a>
-    <a href="https://tls-v1-0.{{ site.domain }}/" class="dubious"><span class="icon"></span>TLS 1.0</a>
-    <a href="https://tls-v1-1.{{ site.domain }}/" class="dubious"><span class="icon"></span>TLS 1.1</a>
-  </div>
-  <div class="group">
     <h2 id="cipher-suite"><span class="emoji">🔀</span>Cipher Suite</h2>
     <a href="https://cbc.{{ site.domain }}/" class="dubious"><span class="icon"></span>cbc</a>
     <a href="https://rc4-md5.{{ site.domain }}/" class="bad"><span class="icon"></span>rc4-md5</a>
@@ -115,7 +108,12 @@
     <a href="https://static-rsa.{{ site.domain }}/" class="dubious"><span class="icon"></span>static-rsa</a>
   </div>
   <div class="group">
-    <h2 id="key-exchange"><span class="emoji">🔍</span>Certificate Transparency</h2>
+    <h2 id="protocol"><span class="emoji">↔️</span>Protocol</h2>
+    <a href="https://tls-v1-0.{{ site.domain }}:1010/" class="dubious"><span class="icon"></span>tls-v1-0</a>
+    <a href="https://tls-v1-1.{{ site.domain }}:1011/" class="dubious"><span class="icon"></span>tls-v1-1</a>
+  </div>
+  <div class="group">
+    <h2 id="certificate-transparency"><span class="emoji">🔍</span>Certificate Transparency</h2>
     <a href="https://invalid-expected-sct.{{ site.domain }}/" class="bad"><span class="icon"></span>invalid-expected-sct</a>
   </div>
   <div class="group">

--- a/domains/misc/badssl.com/index.js
+++ b/domains/misc/badssl.com/index.js
@@ -8,6 +8,7 @@ function getBrowserVersion(ua) {
     [/^.*CriOS\/([\d\.]*)\b.*$/, "Chrome $1"],
     [/^.*Firefox\/([\d\.]*)\b.*$/, "Firefox $1"],
     [/^.*OPR\/([\d\.]*)\b.*$/, "Opera $1"],
+    [/^.*Vivaldi\/([\d\.]*)\b.*$/, "Vivaldi $1"],
     [/^.*OPiOS\/([\d\.]*)\b.*$/, "Opera Mini $1"],
     [/^.*FxiOS\/([\d\.]*)\b.*$/, "Firefox (for iOS) $1"],
     [/^.*Chrome\/([\d\.]*)\b.*$/, "Chrome $1"],


### PR DESCRIPTION
This PR adds TLS1.0, TLS1.1, SSLv2 and SSLv3 to the front page under the client section. Also the Dashboard now checks SSLv3 and SSLv2