### PR TITLE
Update installation instructions in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,8 +29,7 @@ Stock Ubuntu VM, DNS A records for `badssl.com.` and `*.badssl.com.` pointing to
 5. You can now navigate to `badssl.test` in your browser, and you should see a certificate error.
 
 6. The badssl root certificate is at `certs/sets/test/gen/crt/ca-root.crt`. In order to get the rest of the badssl subdomains working, you will need to add this to your machine's list of trusted certificates.
-    - #### macOS X
-      Save `certs/sets/test/gen/crt/ca-root.crt` to your Desktop and drag it into the program Keychain Access. A <b>BadSSL Root Certificate Authority</b> entry should appear in the list. Double-click on this entry and select "Always Trust" from the drop-down menu next to "When using this certificate." Close the window to save your changes.
+    - On <b>macOS X,</b> save `certs/sets/test/gen/crt/ca-root.crt` to your Desktop and drag it into the program Keychain Access. A BadSSL Root Certificate Authority entry should appear in the list. Double-click on this entry and select "Always Trust" from the drop-down menu next to "When using this certificate." Close the window to save your changes.
 
 7. In order to preserve the root certificate even after running `make clean`, run:
 

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Stock Ubuntu VM, DNS A records for `badssl.com.` and `*.badssl.com.` pointing to
 5. You can now navigate to `badssl.test` in your browser, and you should see a certificate error.
 
 6. The badssl root certificate is at `certs/sets/test/gen/crt/ca-root.crt`. In order to get the rest of the badssl subdomains working, you will need to add this to your machine's list of trusted certificates.
-    - On <b>macOS X,</b> save `certs/sets/test/gen/crt/ca-root.crt` to your Desktop and drag it into the program Keychain Access. A BadSSL Root Certificate Authority entry should appear in the list. Double-click on this entry and select "Always Trust" from the drop-down menu next to "When using this certificate." Close the window to save your changes.
+    - On `macOS`, save `certs/sets/test/gen/crt/ca-root.crt` to your Desktop and drag it into the program Keychain Access. A BadSSL Root Certificate Authority entry should appear in the list. Double-click on this entry and select "Always Trust" from the drop-down menu next to "When using this certificate." Close the window to save your changes.
 
 7. In order to preserve the root certificate even after running `make clean`, run:
 

--- a/README.md
+++ b/README.md
@@ -18,21 +18,29 @@ Stock Ubuntu VM, DNS A records for `badssl.com.` and `*.badssl.com.` pointing to
 
 ### Testing and development
 
-Your need to [install Docker](https://www.docker.com/get-docker) to run badssl.com locally.
+1. Follow the instructions to [install Docker.](https://www.docker.com/get-docker)
 
-    git clone https://github.com/chromium/badssl.com && cd badssl.com
-    make list-hosts # list of domains to copy into /etc/hosts
+2. Clone into the badssl repo by running `git clone https://github.com/chromium/badssl.com && cd badssl.com`.
+ 
+3. In order to access the various badssl subdomains locally you will need to add them to your [system hosts file](http://bencane.com/2013/10/29/managing-dns-locally-with-etchosts/). Run `make list-hosts` and copy and paste the output into `/etc/hosts`. 
 
-    # Make sure Docker is running before the next line.
-    make serve
+4. Start Docker by running `make serve`.
 
-Now you can visit `badssl.test` in your browser.
-The root CA is at `certs/sets/test/gen/crt/ca-root.crt`. If you'd like to preserve it even when you run `make clean`, run:
+5. You can now navigate to `badssl.test` in your browser, and you should see a certificate error.
 
-    cd certs/sets/test
-    mkdir -p pregen/crt pregen/key
-    cp gen/crt/ca-root.crt pregen/crt/ca-root.crt
-    cp gen/key/ca-root.key pregen/key/ca-root.key
+6. The badssl root certificate is at `certs/sets/test/gen/crt/ca-root.crt`. In order to get the rest of the badssl subdomains working, you will need to add this to your machine's list of trusted certificates.
+
+##### Mac OS X
+Save `certs/sets/test/gen/crt/ca-root.crt` to your Desktop and drag it into the program Keychain Access. A <b>BadSSL Root Certificate Authority</b> entry should appear in the list. Double-click on this entry and select "Always Trust" from the drop-down menu next to "When using this certificate." Close the window to save your changes.
+
+7. In order to preserve the root certificate even after running `make clean`, run:
+
+```
+cd certs/sets/test
+mkdir -p pregen/crt pregen/key
+cp gen/crt/ca-root.crt pregen/crt/ca-root.crt
+cp gen/key/ca-root.key pregen/key/ca-root.key
+``` 
 
 ## Acknowledgments
 

--- a/README.md
+++ b/README.md
@@ -22,16 +22,15 @@ Stock Ubuntu VM, DNS A records for `badssl.com.` and `*.badssl.com.` pointing to
 
 2. Clone into the badssl repo by running `git clone https://github.com/chromium/badssl.com && cd badssl.com`.
  
-3. In order to access the various badssl subdomains locally you will need to add them to your [system hosts file](http://bencane.com/2013/10/29/managing-dns-locally-with-etchosts/). Run `make list-hosts` and copy and paste the output into `/etc/hosts`. 
+3. In order to access the various badssl subdomains locally you will need to add them to your [system hosts file](https://bencane.com/2013/10/29/managing-dns-locally-with-etchosts/). Run `make list-hosts` and copy and paste the output into `/etc/hosts`. 
 
 4. Start Docker by running `make serve`.
 
 5. You can now navigate to `badssl.test` in your browser, and you should see a certificate error.
 
 6. The badssl root certificate is at `certs/sets/test/gen/crt/ca-root.crt`. In order to get the rest of the badssl subdomains working, you will need to add this to your machine's list of trusted certificates.
-
-##### Mac OS X
-Save `certs/sets/test/gen/crt/ca-root.crt` to your Desktop and drag it into the program Keychain Access. A <b>BadSSL Root Certificate Authority</b> entry should appear in the list. Double-click on this entry and select "Always Trust" from the drop-down menu next to "When using this certificate." Close the window to save your changes.
+    - #### macOS X
+      Save `certs/sets/test/gen/crt/ca-root.crt` to your Desktop and drag it into the program Keychain Access. A <b>BadSSL Root Certificate Authority</b> entry should appear in the list. Double-click on this entry and select "Always Trust" from the drop-down menu next to "When using this certificate." Close the window to save your changes.
 
 7. In order to preserve the root certificate even after running `make clean`, run:
 


### PR DESCRIPTION
I expanded the installation instructions in the README in order to address a few pain points I had while setting up badssl.