### PR TITLE
Added Firefox 44 in pinning-test

### DIFF
--- a/domains/cert/pinning-test/index.html
+++ b/domains/cert/pinning-test/index.html
@@ -12,5 +12,5 @@ background: red
 </div>
 
 <div id="footer">
-  This site is preloaded with a bad HPKP pin starting in Chrome 48.
+  This site is preloaded with a bad <a href="https://en.wikipedia.org/wiki/HTTP_Public_Key_Pinning">HPKP</a> pin starting in<br> Chrome 48 and Firefox 44.
 </div>


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/24654097/30295804-d35c7636-9739-11e7-9bb9-15e8df6a6495.png)

pinning-test.badssl.com was added to Firefox 44 by bug ID: 1218515.