### PR TITLE
Add libffi-dev to the required packages in Docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,6 +5,7 @@ EXPOSE 80 443
 RUN apt-get update && apt-get install -y \
     build-essential \
     git \
+    libffi-dev \
     make \
     nginx \
     ruby \


### PR DESCRIPTION
For some reason `ruby gem` fails with the current version of Ubuntu. Adding libffi-dev to the required libraries seems to have fixed it.