### PR TITLE
Add `tls-v1-2` subdomain. Addresses #332.

### DIFF
--- a/domains/misc/badssl.com/dashboard/sets.js
+++ b/domains/misc/badssl.com/dashboard/sets.js
@@ -50,6 +50,7 @@ var sets = [
     success: "yes",
     fail: "no",
     subdomains: [
+      {subdomain: "tls-v1-2", port: 1012},
       {subdomain: "sha256"},
       {subdomain: "sha384"},
       {subdomain: "sha512"},

--- a/domains/misc/badssl.com/index.html
+++ b/domains/misc/badssl.com/index.html
@@ -115,6 +115,7 @@
     <h2 id="protocol"><span class="emoji">↔️</span>Protocol</h2>
     <a href="https://tls-v1-0.{{ site.domain }}:1010/" class="dubious"><span class="icon"></span>tls-v1-0</a>
     <a href="https://tls-v1-1.{{ site.domain }}:1011/" class="dubious"><span class="icon"></span>tls-v1-1</a>
+    <a href="https://tls-v1-2.{{ site.domain }}:1012/" class="good"><span class="icon"></span>tls-v1-2</a>
   </div>
   <div class="group">
     <h2 id="certificate-transparency"><span class="emoji">🔍</span>Certificate Transparency</h2>

--- a/domains/protocol/tls-v1-2.conf
+++ b/domains/protocol/tls-v1-2.conf
@@ -1,0 +1,29 @@
+---
+---
+server {
+  listen 80;
+  server_name tls-v1-2.{{ site.domain }};
+  
+  return 301 https://$server_name:1011$request_uri;
+}
+
+server {
+  listen 443;
+  server_name tls-v1-2.{{ site.domain }};
+
+  include {{ site.serving-path }}/nginx-includes/wildcard-normal.conf;
+  include {{ site.serving-path }}/nginx-includes/tls-defaults.conf;
+
+  return 301 https://$server_name:1011$request_uri;
+}
+
+server {
+  listen 1012;
+  server_name tls-v1-2.{{ site.domain }};
+
+  include {{ site.serving-path }}/nginx-includes/wildcard-normal.conf;
+  include {{ site.serving-path }}/nginx-includes/tls-v1-2.conf;
+  include {{ site.serving-path }}/common/common.conf;
+
+  root {{ site.serving-path }}/domains/protocol/tls-v1-2;
+}

--- a/domains/protocol/tls-v1-2/index.html
+++ b/domains/protocol/tls-v1-2/index.html
@@ -1,0 +1,12 @@
+---
+subdomain: tls-v1-2
+layout: page
+favicon: green
+background: green
+---
+
+<div id="content">
+  <h1 style="font-size: 12vw;">
+    {{ page.subdomain }}.<br>{{ site.domain }}
+  </h1>
+</div>

--- a/nginx-includes/tls-v1-2.conf
+++ b/nginx-includes/tls-v1-2.conf
@@ -1,0 +1,6 @@
+---
+---
+
+ssl_session_timeout 5m;
+
+ssl_protocols TLSv1.2;


### PR DESCRIPTION
@christhompson, could you review?

This adds `tls-v1-2` on port 1012, similar to how other protocol subdomains are implemented.