### PR TITLE
Change 'make link' to be idempotent

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -70,7 +70,10 @@ install-keys:
 link:
 	if [ ! -d /var/www ]; then mkdir -p /var/www; fi
 	if [ ! -d /var/www/badssl ]; then ln -sf "`pwd`" /var/www/badssl; fi
-	if [ -f /etc/nginx/nginx.conf ] ; then sed -i '/Virtual Host Configs/a include /var/www/badssl/_site/nginx.conf;' /etc/nginx/nginx.conf; else @echo "Please add `pwd`/_site/nginx.conf to your nginx.conf configuration."; fi
+	# Add the badssl.conf include to /etc/nginx/nginx.conf only if it is not already in the config.
+	if ! `grep -q "include /var/www/badssl/_site/nginx.conf" /etc/nginx/nginx.conf`; then sed -i '/# Virtual Host Configs/,/^$/s@^$@\tinclude /var/www/badssl/_site/nginx.conf;\n@' /etc/nginx/nginx.conf; fi
+	# If /etc/nginx/nginx.conf doesn't exist, alert the user that the include must be manually added.
+	if [ ! -f /etc/nginx/nginx.conf ]; then @echo "Please add `pwd`/_site/nginx.conf to your nginx.conf configuration."; fi
 
 .PHONY: install
 install: install-keys link

--- a/Makefile
+++ b/Makefile
@@ -71,9 +71,14 @@ link:
 	if [ ! -d /var/www ]; then mkdir -p /var/www; fi
 	if [ ! -d /var/www/badssl ]; then ln -sf "`pwd`" /var/www/badssl; fi
 	# Add the badssl.conf include to /etc/nginx/nginx.conf only if it is not already in the config.
-	if ! `grep -q "include /var/www/badssl/_site/nginx.conf" /etc/nginx/nginx.conf`; then sed -i '/# Virtual Host Configs/,/^$/s@^$@\tinclude /var/www/badssl/_site/nginx.conf;\n@' /etc/nginx/nginx.conf; fi
-	# If /etc/nginx/nginx.conf doesn't exist, alert the user that the include must be manually added.
-	if [ ! -f /etc/nginx/nginx.conf ]; then @echo "Please add `pwd`/_site/nginx.conf to your nginx.conf configuration."; fi
+	# If /etc/nginx/nginx.conf does not exist, instead warn the user that it must be manually added.
+	if [ -f /etc/nginx/nginx.conf ]; then \
+		if ! grep -q "include /var/www/badssl/_site/nginx.conf" /etc/nginx/nginx.conf; then \
+			sed -i '/# Virtual Host Configs/a\\tinclude /var/www/badssl/_site/nginx.conf;' /etc/nginx/nginx.conf; \
+		fi \
+	else \
+		@echo "Please add `pwd`/_site/nginx.conf to your nginx.conf configuration."; \
+	fi
 
 .PHONY: install
 install: install-keys link


### PR DESCRIPTION
The current `make link` target checks if `/etc/nginx/nginx.conf` exists, and if it doesn't then it adds the virtual host include for the badssl config. However, it `make link` is run more than once (such as during a re-install on a previously deployed server), this can cause the line to be added more than once (and then causing the nginx config to fail).

This changes it to explicitly test if the line exists in the file, and if it does not then it adds it to the next line.

It also separates out the file existence check and warning.