### PR TITLE
Add page with 🔒 in title

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,4 +18,5 @@ WORKDIR badssl.com
 RUN make inside-docker
 
 # Start things up!
+RUN chmod -R +r /var/www/badssl
 CMD nginx && tail -f /var/log/nginx/access.log /var/log/nginx/error.log

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,5 +18,4 @@ WORKDIR badssl.com
 RUN make inside-docker
 
 # Start things up!
-RUN chmod -R +r /var/www/badssl
 CMD nginx && tail -f /var/log/nginx/access.log /var/log/nginx/error.log

--- a/_layouts/page.html
+++ b/_layouts/page.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html>
 <head>
+  <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   {% if page.no-favicon %}<!-- No favicon -->{% else %}<link rel="shortcut icon" href="/icons/favicon-{{ page.favicon }}.ico"/>
   <link rel="apple-touch-icon" href="/icons/icon-{{ page.favicon }}.png"/>{% endif %}

--- a/domains/misc/badssl.com/index.html
+++ b/domains/misc/badssl.com/index.html
@@ -134,6 +134,7 @@
   <div class="group">
     <h2 id="ui"><span class="emoji">👀</span>UI</h2>
     <a href="https://spoofed-favicon.{{ site.domain }}/" class="dubious"><span class="icon"></span>spoofed-favicon</a>
+    <a href="https://lock-title.{{ site.domain }}/" class="dubious"><span class="icon"></span>lock-title</a>
     <hr>
     <a href="https://long-extended-subdomain-name-containing-many-letters-and-dashes.{{ site.domain }}/" class="good"><span class="icon"></span>long-extended-subdomain-name-containing-many-letters-and-dashes</a>
     <a href="https://longextendedsubdomainnamewithoutdashesinordertotestwordwrapping.{{ site.domain }}/" class="good"><span class="icon"></span>longextendedsubdomainnamewithoutdashesinordertotestwordwrapping</a>

--- a/domains/ui/lock-title.conf
+++ b/domains/ui/lock-title.conf
@@ -1,0 +1,21 @@
+---
+---
+server {
+  listen 80 ;
+  server_name lock-title.{{ site.domain }};
+
+  include {{ site.serving-path }}/common/common.conf;
+
+  root {{ site.serving-path }}/domains/ui/lock-title;
+}
+
+server {
+  listen 443;
+  server_name lock-title.{{ site.domain }};
+
+  include {{ site.serving-path }}/common/common.conf;
+  include {{ site.serving-path }}/nginx-includes/wildcard-normal.conf;
+  include {{ site.serving-path }}/nginx-includes/tls-defaults.conf;
+
+  root {{ site.serving-path }}/domains/ui/lock-title;
+}

--- a/domains/ui/lock-title/index.html
+++ b/domains/ui/lock-title/index.html
@@ -1,0 +1,16 @@
+---
+subdomain: lock-title
+layout: page
+title: 🔒 lock-title
+background: gray
+---
+
+<div id="content">
+  <h1 style="font-size: 10vw;">
+    {{ page.subdomain }}.<br />{{ site.domain }}
+  </h1>
+</div>
+
+<div id="footer">
+  This site's title contains a <a href="https://emojipedia.org/lock/">lock emoji</a>, which can potentially be confused for the TLS lock icon. Safari does not display the lock in the title.
+</div>


### PR DESCRIPTION
This adds `lock-title.badssl.com` (available over both http:// and https://), which sets the page title to "🔒 lock-title".

Fixes #329 