### PR TITLE
Fix permissions in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,4 +18,5 @@ WORKDIR badssl.com
 RUN make inside-docker
 
 # Start things up!
+RUN chmod -R +r /var/www/badssl
 CMD nginx && tail -f /var/log/nginx/access.log /var/log/nginx/error.log


### PR DESCRIPTION
When working on #388, running `make serve` led to nginx throwing lots of permission errors. This adds an extra command run before the main entrypoint in `Dockerfile` to ensure that all assets in `/var/www/badssl` are readable by nginx. This should make the testing server a little more robust.