### PR TITLE
Mark DHE as bad or dubious

### DIFF
--- a/domains/key-exchange/dh1024/index.html
+++ b/domains/key-exchange/dh1024/index.html
@@ -1,8 +1,8 @@
 ---
 subdomain: dh1024
 layout: page
-favicon: yellow
-background: rgb(246, 207, 47)
+favicon: red
+background: red
 ---
 
 <div id="content">

--- a/domains/key-exchange/dh2048/index.html
+++ b/domains/key-exchange/dh2048/index.html
@@ -1,8 +1,8 @@
 ---
 subdomain: dh2048
 layout: page
-favicon: green
-background: green
+favicon: yellow
+background: rgb(246, 207, 47)
 ---
 
 <div id="content">

--- a/domains/misc/badssl.com/dashboard/sets.js
+++ b/domains/misc/badssl.com/dashboard/sets.js
@@ -49,7 +49,8 @@ var sets = [
       {subdomain: "tls-v1-0", port: 1010},
       {subdomain: "tls-v1-1", port: 1011},
       {subdomain: "cbc"},
-      {subdomain: "3des"}
+      {subdomain: "3des"},
+      {subdomain: "dh2048"}
     ]
   },
   {

--- a/domains/misc/badssl.com/index.html
+++ b/domains/misc/badssl.com/index.html
@@ -103,8 +103,8 @@
     <h2 id="key-exchange"><span class="emoji">🔑</span>Key Exchange</h2>
     <a href="https://dh480.{{ site.domain }}/" class="bad"><span class="icon"></span>dh480</a>
     <a href="https://dh512.{{ site.domain }}/" class="bad"><span class="icon"></span>dh512</a>
-    <a href="https://dh1024.{{ site.domain }}/" class="dubious"><span class="icon"></span>dh1024</a>
-    <a href="https://dh2048.{{ site.domain }}/" class="good"><span class="icon"></span>dh2048</a>
+    <a href="https://dh1024.{{ site.domain }}/" class="bad"><span class="icon"></span>dh1024</a>
+    <a href="https://dh2048.{{ site.domain }}/" class="dubious"><span class="icon"></span>dh2048</a>
     <hr>
     <a href="https://dh-small-subgroup.{{ site.domain }}/" class="bad"><span class="icon"></span>dh-small-subgroup</a>
     <a href="https://dh-composite.{{ site.domain }}/" class="bad"><span class="icon"></span>dh-composite</a>


### PR DESCRIPTION
This updates the icons/labels for dh1024 and dh2048 from "dubious" and "good" to "bad" and "dubious", and adds dh2048 to the "Legacy Cryptography" section of the Dashboard.

It is now over two years since non-EC DHE support was removed from Chrome (https://www.chromestatus.com/feature/5128908798164992) after the Logjam attacks indicated that DHE key exchange was generally insecure. While 2048-bit DH is still ~okay (that's large enough that we don't think it's currently breakable, but attacks only get better), I think it makes sense to mark it as "dubious" and add it to the "Legacy Cryptography" section of the dashboard. Modern configurations should strongly favor ECDHE.

1024-bit DH was already added to the Dashboard view under "Broken Cryptography", so actively labeling it as "bad" on the front page would align the two.

This closes #313.