### PR TITLE
Add (known|blocked)-interception.badssl.com tests

### DIFF
--- a/certs/Makefile
+++ b/certs/Makefile
@@ -448,6 +448,34 @@ CHAINS_PROD += $(O)/gen/chain/subdomain-captive-portal.pem
 $(O)/gen/chain/subdomain-captive-portal.pem: $(O)/gen/crt/subdomain-captive-portal.crt $(O)/gen/crt/ca-intermediate.crt
 	./tool chain $@ $(D) $^
 
+################################
+$(O)/gen/key/leaf-blocked-interception.key:
+	./tool gen-key $@ $(D) 2048
+
+################################
+# Note: this is just a regular cert in `test`
+$(O)/gen/csr/subdomain-blocked-interception.csr: src/conf/subdomain-blocked-interception.conf $(O)/gen/key/leaf-blocked-interception.key
+	./tool gen-csr $@ $(D) $^
+$(O)/gen/crt/subdomain-blocked-interception.crt: src/conf/subdomain-blocked-interception.conf $(O)/gen/csr/subdomain-blocked-interception.csr $(O)/gen/key/ca-intermediate.key $(O)/gen/crt/ca-intermediate.crt
+	./tool sign $@ $(D) $(SIGN_LEAF_DEFAULTS) $^
+CHAINS_PROD += $(O)/gen/chain/subdomain-blocked-interception.pem
+$(O)/gen/chain/subdomain-blocked-interception.pem: $(O)/gen/crt/subdomain-blocked-interception.crt $(O)/gen/crt/ca-intermediate.crt
+	./tool chain $@ $(D) $^
+
+################################
+$(O)/gen/key/leaf-known-interception.key:
+	./tool gen-key $@ $(D) 2048
+
+################################
+# Note: this is just a regular cert in `test`
+$(O)/gen/csr/subdomain-known-interception.csr: src/conf/subdomain-known-interception.conf $(O)/gen/key/leaf-known-interception.key
+	./tool gen-csr $@ $(D) $^
+$(O)/gen/crt/subdomain-known-interception.crt: src/conf/subdomain-known-interception.conf $(O)/gen/csr/subdomain-known-interception.csr $(O)/gen/key/ca-intermediate.key $(O)/gen/crt/ca-intermediate.crt
+	./tool sign $@ $(D) $(SIGN_LEAF_DEFAULTS) $^
+CHAINS_PROD += $(O)/gen/chain/subdomain-known-interception.pem
+$(O)/gen/chain/subdomain-known-interception.pem: $(O)/gen/crt/subdomain-known-interception.crt $(O)/gen/crt/ca-intermediate.crt
+	./tool chain $@ $(D) $^
+
 
 ################################
 $(O)/gen/dhparam/dh480.pem:

--- a/certs/src/conf/subdomain-blocked-interception.conf
+++ b/certs/src/conf/subdomain-blocked-interception.conf
@@ -1,0 +1,20 @@
+[ req ]
+default_bits        = 2048
+distinguished_name  = req_distinguished_name
+encrypt_key         = no
+prompt              = no
+req_extensions      = req_v3_usr
+
+[ req_distinguished_name ]
+countryName         = US
+stateOrProvinceName = California
+localityName        = San Francisco
+organizationName    = BadSSL
+commonName          = blocked-interception.__DOMAIN__
+
+[ req_v3_usr ]
+basicConstraints = CA:FALSE
+subjectAltName = @alt_names
+
+[ alt_names ]
+DNS.1 = blocked-interception.__DOMAIN__

--- a/certs/src/conf/subdomain-known-interception.conf
+++ b/certs/src/conf/subdomain-known-interception.conf
@@ -1,0 +1,20 @@
+[ req ]
+default_bits        = 2048
+distinguished_name  = req_distinguished_name
+encrypt_key         = no
+prompt              = no
+req_extensions      = req_v3_usr
+
+[ req_distinguished_name ]
+countryName         = US
+stateOrProvinceName = California
+localityName        = San Francisco
+organizationName    = BadSSL
+commonName          = known-interception.__DOMAIN__
+
+[ req_v3_usr ]
+basicConstraints = CA:FALSE
+subjectAltName = @alt_names
+
+[ alt_names ]
+DNS.1 = known-interception.__DOMAIN__

--- a/domains/cert/blocked-interception.conf
+++ b/domains/cert/blocked-interception.conf
@@ -1,0 +1,19 @@
+---
+---
+server {
+  listen 80;
+  server_name blocked-interception.{{ site.domain }};
+
+  return 301 https://$server_name$request_uri;
+}
+
+server {
+  listen 443;
+  server_name blocked-interception.{{ site.domain }};
+
+  include {{ site.serving-path }}/nginx-includes/subdomain-blocked-interception.conf;
+  include {{ site.serving-path }}/nginx-includes/tls-defaults.conf;
+  include {{ site.serving-path }}/common/common.conf;
+
+  root {{ site.serving-path }}/domains/cert/blocked-interception;
+}

--- a/domains/cert/blocked-interception/index.html
+++ b/domains/cert/blocked-interception/index.html
@@ -1,0 +1,16 @@
+---
+subdomain: blocked-interception
+layout: page
+favicon: red
+background: red
+---
+
+<div id="content">
+  <h1 style="font-size: 10vw;">
+    {{ page.subdomain }}.<br>{{ site.domain }}
+  </h1>
+</div>
+
+<div id="footer">
+  The certificate for this site is associated with network interception.
+</div>

--- a/domains/cert/known-interception.conf
+++ b/domains/cert/known-interception.conf
@@ -1,0 +1,19 @@
+---
+---
+server {
+  listen 80;
+  server_name known-interception.{{ site.domain }};
+
+  return 301 https://$server_name$request_uri;
+}
+
+server {
+  listen 443;
+  server_name known-interception.{{ site.domain }};
+
+  include {{ site.serving-path }}/nginx-includes/subdomain-known-interception.conf;
+  include {{ site.serving-path }}/nginx-includes/tls-defaults.conf;
+  include {{ site.serving-path }}/common/common.conf;
+
+  root {{ site.serving-path }}/domains/cert/known-interception;
+}

--- a/domains/cert/known-interception/index.html
+++ b/domains/cert/known-interception/index.html
@@ -1,0 +1,16 @@
+---
+subdomain: blocked-interception
+layout: page
+favicon: gray
+background: gray
+---
+
+<div id="content">
+  <h1 style="font-size: 10vw;">
+    {{ page.subdomain }}.<br>{{ site.domain }}
+  </h1>
+</div>
+
+<div id="footer">
+  The certificate for this site is associated with network interception.
+</div>

--- a/nginx-includes/subdomain-blocked-interception.conf
+++ b/nginx-includes/subdomain-blocked-interception.conf
@@ -1,0 +1,6 @@
+---
+---
+
+ssl on;
+ssl_certificate {{ site.cert-path }}/subdomain-blocked-interception.pem;
+ssl_certificate_key /etc/keys/leaf-blocked-interception.key;

--- a/nginx-includes/subdomain-known-interception.conf
+++ b/nginx-includes/subdomain-known-interception.conf
@@ -1,0 +1,6 @@
+---
+---
+
+ssl on;
+ssl_certificate {{ site.cert-path }}/subdomain-known-interception.pem;
+ssl_certificate_key /etc/keys/leaf-known-interception.key;


### PR DESCRIPTION
In Chrome, we are adding two new variations of CRLSets for when we want to block or alert on certificates or roots that are known to be used for network interception and monitoring (the new CRLSet types and errors were added in https://crrev.com/c/1904545).

To help with manual testing, this PR adds two new subdomains that will serve new (trusted) certificates with new keys for each:

- blocked-interception.badssl.com (Chrome would show a new interstitial)
- known-interception.badssl.com (Chrome would show a new passive warning)

After these certificates are issued, my plan is to add them to the new CRLSets lists (in Chrome source and in the component). Non-Chrome browsers won't pick up these new CRLSets by default.

I wanted to file the initial version of this PR to solicit reviews from before ordering the certificates (once we have the certs I'll add the chains to this PR). @lgarron what do you think?