### PR TITLE
Mark invalid-expected-sct and sha1-intermediate as Defunct

### DIFF
--- a/domains/misc/badssl.com/dashboard/sets.js
+++ b/domains/misc/badssl.com/dashboard/sets.js
@@ -31,7 +31,6 @@ var sets = [
     success: "no",
     fail: "yes",
     subdomains: [
-      {subdomain: "sha1-intermediate"},
       {subdomain: "rc4"},
       {subdomain: "rc4-md5"},
       {subdomain: "dh480"},
@@ -61,7 +60,6 @@ var sets = [
     subdomains: [
       {subdomain: "revoked"},
       {subdomain: "pinning-test"},
-      {subdomain: "invalid-expected-sct"},
       {subdomain: "no-sct"}
     ]
   },

--- a/domains/misc/badssl.com/index.html
+++ b/domains/misc/badssl.com/index.html
@@ -43,7 +43,6 @@
     <a href="https://no-subject.{{ site.domain }}/" class="dubious"><span class="icon"></span>no-subject</a>
     <a href="https://incomplete-chain.{{ site.domain }}/" class="dubious"><span class="icon"></span>incomplete-chain</a>
     <hr>
-    <a href="https://sha1-intermediate.{{ site.domain }}/" class="bad"><span class="icon"></span>sha1-intermediate</a>
     <a href="https://sha256.{{ site.domain }}/" class="good"><span class="icon"></span>sha256</a>
     <a href="https://sha384.{{ site.domain }}/" class="good"><span class="icon"></span>sha384</a>
     <a href="https://sha512.{{ site.domain }}/" class="good"><span class="icon"></span>sha512</a>
@@ -119,7 +118,6 @@
   </div>
   <div class="group">
     <h2 id="certificate-transparency"><span class="emoji">🔍</span>Certificate Transparency</h2>
-    <a href="https://invalid-expected-sct.{{ site.domain }}/" class="bad"><span class="icon"></span>invalid-expected-sct</a>
     <a href="https://no-sct.{{ site.domain }}/" class="bad"><span class="icon"></span>no-sct</a>
   </div>
   <div class="group">
@@ -157,6 +155,8 @@
     <h2 id="defunct"><span class="emoji">☠️</span>Defunct</h2>
     <a href="https://sha1-2016.{{ site.domain }}/" class="dubious"><span class="icon"></span>sha1-2016</a>
     <a href="https://sha1-2017.{{ site.domain }}/" class="bad"><span class="icon"></span>sha1-2017</a>
+    <a href="https://sha1-intermediate.{{ site.domain }}/" class="bad"><span class="icon"></span>sha1-intermediate</a>
+    <a href="https://invalid-expected-sct.{{ site.domain }}/" class="bad"><span class="icon"></span>invalid-expected-sct</a>
   </div>
   <div class="group">
     <h2 id="test-suites"><span class="emoji">🛠</span>Test Suites</h2>


### PR DESCRIPTION
`invalid-expected-sct` has expired with no way to renew it (replaced by `no-sct`). Similarly, `sha1-intermediate` will expire on May 30, 2020, and CAs can no longer issue new ones using SHA-1. This moves both to the "Defunct" section of the homepage and removes them from the dashboard.

Fixes #416 