### PR TITLE
No Subject Information Link Updated (temporarily)

### DIFF
--- a/domains/misc/badssl.com/index.html
+++ b/domains/misc/badssl.com/index.html
@@ -40,7 +40,7 @@
     <a href="https://pinning-test.{{ site.domain }}/" class="bad"><span class="icon"></span>pinning-test</a>
     <hr>
     <a href="https://no-common-name.{{ site.domain }}/" class="dubious"><span class="icon"></span>no-common-name</a>
-    <a href="https://no-subject.{{ site.domain }}/" class="dubious"><span class="icon"></span>no-subject</a>
+    <a href="https://www.obtains.co.uk/" class="dubious"><span class="icon"></span>no-subject</a>
     <a href="https://incomplete-chain.{{ site.domain }}/" class="dubious"><span class="icon"></span>incomplete-chain</a>
     <hr>
     <a href="https://sha256.{{ site.domain }}/" class="good"><span class="icon"></span>sha256</a>


### PR DESCRIPTION
I've updated the no-subject link (temporarily) to forward to my test website which has a no subject information certificate. The website is hosted on Google app engine and the certificate will be updated every 3 months.  