### PR TITLE
Remove reversed-chain from homepage/dashboard

### DIFF
--- a/domains/misc/badssl.com/dashboard/sets.js
+++ b/domains/misc/badssl.com/dashboard/sets.js
@@ -92,7 +92,6 @@ var sets = [
       {subdomain: "ecc384"},
       {subdomain: "extended-validation"},
       {subdomain: "mozilla-modern"},
-      {subdomain: "reversed-chain"}
     ]
   }
 ];

--- a/domains/misc/badssl.com/index.html
+++ b/domains/misc/badssl.com/index.html
@@ -42,7 +42,6 @@
     <a href="https://no-common-name.{{ site.domain }}/" class="dubious"><span class="icon"></span>no-common-name</a>
     <a href="https://no-subject.{{ site.domain }}/" class="dubious"><span class="icon"></span>no-subject</a>
     <a href="https://incomplete-chain.{{ site.domain }}/" class="dubious"><span class="icon"></span>incomplete-chain</a>
-    <a href="https://reversed-chain.{{ site.domain }}/" class="dubious"><span class="icon"></span>reversed-chain</a>
     <hr>
     <a href="https://sha256.{{ site.domain }}/" class="good"><span class="icon"></span>sha256</a>
     <a href="https://sha384.{{ site.domain }}/" class="good"><span class="icon"></span>sha384</a>


### PR DESCRIPTION
This is (unfortunately) currently broken due to nginx not allowing us to intentionally serve a chain out-of-order (see https://github.com/chromium/badssl.com/pull/443#issuecomment-784556007 for details). For now, remove this test case from the dashboard and homepage lists until we can figure out a solution.