### PR TITLE
Use bobbucks instead of basic-card on web-payment page.

### DIFF
--- a/common/input/web-payment/index.js
+++ b/common/input/web-payment/index.js
@@ -33,7 +33,7 @@ function toggleLogVisibility() {
 function initPaymentRequest() {
   const request = new PaymentRequest(
       [{
-        supportedMethods: ['https://bobbucks.dev/pay'],
+        supportedMethods: 'https://bobbucks.dev/pay',
       }],
       {
         total: {

--- a/common/input/web-payment/index.js
+++ b/common/input/web-payment/index.js
@@ -33,7 +33,7 @@ function toggleLogVisibility() {
 function initPaymentRequest() {
   const request = new PaymentRequest(
       [{
-        supportedMethods: ['basic-card'],
+        supportedMethods: ['https://bobbucks.dev/pay'],
       }],
       {
         total: {


### PR DESCRIPTION
The basic-card feature is being deprecated, so this test page is updated to use a test payment app instead.