### PR TITLE
Add MD5 and SHA-1 server signatures

### DIFF
--- a/domains/misc/badssl.com/dashboard/sets.js
+++ b/domains/misc/badssl.com/dashboard/sets.js
@@ -37,6 +37,7 @@ var sets = [
       {subdomain: "dh512"},
       {subdomain: "dh1024"},
       {subdomain: "null"}
+      {subdomain: "md5-server-signature"},
     ]
   },
   {
@@ -50,6 +51,7 @@ var sets = [
       {subdomain: "cbc"},
       {subdomain: "3des"},
       {subdomain: "dh2048"}
+      {subdomain: "sha1-server-signature"},
     ]
   },
   {

--- a/domains/misc/badssl.com/index.html
+++ b/domains/misc/badssl.com/index.html
@@ -111,6 +111,11 @@
     <a href="https://static-rsa.{{ site.domain }}/" class="dubious"><span class="icon"></span>static-rsa</a>
   </div>
   <div class="group">
+    <h2 id="server-signature"><span class="emoji">✒️</span>Server Signature</h2>
+    <a href="https://md5-server-signature.{{ site.domain }}/" class="bad"><span class="icon"></span>md5-server-signature</a>
+    <a href="https://sha1-server-signature.{{ site.domain }}/" class="dubious"><span class="icon"></span>sha1-server-signature</a>
+  </div>
+  <div class="group">
     <h2 id="protocol"><span class="emoji">↔️</span>Protocol</h2>
     <a href="https://tls-v1-0.{{ site.domain }}:1010/" class="dubious"><span class="icon"></span>tls-v1-0</a>
     <a href="https://tls-v1-1.{{ site.domain }}:1011/" class="dubious"><span class="icon"></span>tls-v1-1</a>

--- a/domains/server-signature/md5.conf
+++ b/domains/server-signature/md5.conf
@@ -1,0 +1,19 @@
+---
+---
+server {
+  listen 80;
+  server_name md5-server-signature.{{ site.domain }};
+
+  return 301 https://$server_name$request_uri;
+}
+
+server {
+  listen 443;
+  server_name md5-server-signature.{{ site.domain }};
+
+  include {{ site.serving-path }}/nginx-includes/wildcard-normal.conf;
+  include {{ site.serving-path }}/nginx-includes/tls-md5-signature.conf;
+  include {{ site.serving-path }}/common/common.conf;
+
+  root {{ site.serving-path }}/domains/server-signature/md5;
+}

--- a/domains/server-signature/md5/index.html
+++ b/domains/server-signature/md5/index.html
@@ -1,0 +1,12 @@
+---
+subdomain: md5-server-signature
+layout: page
+favicon: red
+background: red
+---
+
+<div id="content">
+  <h1 style="font-size: 10vw;">
+    {{ page.subdomain }}.{{ site.domain }}
+  </h1>
+</div>

--- a/domains/server-signature/sha1.conf
+++ b/domains/server-signature/sha1.conf
@@ -1,0 +1,19 @@
+---
+---
+server {
+  listen 80;
+  server_name sha1-server-signature.{{ site.domain }};
+
+  return 301 https://$server_name$request_uri;
+}
+
+server {
+  listen 443;
+  server_name sha1-server-signature.{{ site.domain }};
+
+  include {{ site.serving-path }}/nginx-includes/wildcard-normal.conf;
+  include {{ site.serving-path }}/nginx-includes/tls-sha1-signature.conf;
+  include {{ site.serving-path }}/common/common.conf;
+
+  root {{ site.serving-path }}/domains/server-signature/sha1;
+}

--- a/domains/server-signature/sha1/index.html
+++ b/domains/server-signature/sha1/index.html
@@ -1,0 +1,12 @@
+---
+subdomain: sha1-server-signature
+layout: page
+favicon: red
+background: red
+---
+
+<div id="content">
+  <h1 style="font-size: 10vw;">
+    {{ page.subdomain }}.{{ site.domain }}
+  </h1>
+</div>

--- a/nginx-includes/tls-md5-signature.conf
+++ b/nginx-includes/tls-md5-signature.conf
@@ -1,0 +1,10 @@
+---
+---
+
+ssl_session_timeout 5m;
+
+# Limit to TLS 1.2 and ECDHE-based cipher suites, where MD5 server signatures may apply.
+ssl_protocols TLSv1.2;
+ssl_ciphers 'ECDSA+AESGCM:ECDHE:!RC4:!aNULL:!eNULL:!EXPORT:!DES:!3DES:!MD5:!PSK';
+ssl_prefer_server_ciphers on;
+ssl_conf_command SignatureAlgorithms RSA+MD5

--- a/nginx-includes/tls-sha1-signature.conf
+++ b/nginx-includes/tls-sha1-signature.conf
@@ -1,0 +1,10 @@
+---
+---
+
+ssl_session_timeout 5m;
+
+# Limit to TLS 1.2 and ECDHE-based cipher suites, where SHA-1 server signatures may apply.
+ssl_protocols TLSv1.2;
+ssl_ciphers 'ECDSA+AESGCM:ECDHE:!RC4:!aNULL:!eNULL:!EXPORT:!DES:!3DES:!MD5:!PSK';
+ssl_prefer_server_ciphers on;
+ssl_conf_command SignatureAlgorithms RSA+SHA1


### PR DESCRIPTION
These correspond to the configurations deprecated by RFC 9155. I've marked MD5 as "bad" because it really should have been out of clients by now. I've marked SHA-1 as "dubious" for now because it's analogous to TLS 1.0/1.1, and clients still support it for now (but hopefully not for much longer).

(I just copied the existing configuration for the cipher suite pages. Not positive if I've done it right.)